### PR TITLE
Redirect pytest stdout to `/dev/null`

### DIFF
--- a/bundled/tool/xray/__main__.py
+++ b/bundled/tool/xray/__main__.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 from typing import Any, Dict
 
 from .debugger import Debugger
-from .parsing_utils import Config, ParserBuilder
 from .test_filter import TestFilter
+from .utils import Config, ParserBuilder
 
 
 @dataclass

--- a/bundled/tool/xray/test_filter.py
+++ b/bundled/tool/xray/test_filter.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import contextlib
 import os.path
 from typing import Literal, Optional
 
 import pytest
 
 from .debugger import Debugger
+from .utils import silence_output
 
 
 class TestFilter:
@@ -50,13 +50,12 @@ class TestFilter:
         if self.debugger is None:
             return True
 
+    @silence_output
     def collect_tests(self):
-        with open(os.devnull, "w") as devnull:
-            with contextlib.redirect_stdout(devnull):
-                pytest.main(
-                    ["-qq", "--co", "--show-capture=no", "--tb=no", "--no-showlocals"],
-                    plugins=[self],
-                )
+        pytest.main(
+            ["-qq", "--co", "--show-capture=no", "--tb=no", "--no-showlocals"],
+            plugins=[self],
+        )
 
     @classmethod
     def get_tests(cls, filepath: str, function_name: str) -> list[pytest.Item]:
@@ -74,10 +73,9 @@ class TestFilter:
             self.debugger.set_quit()
         return result
 
+    @silence_output
     def collect_and_run_tests(self):
-        with open(os.devnull, "w") as devnull:
-            with contextlib.redirect_stdout(devnull):
-                pytest.main(["-qq"], plugins=[self])
+        pytest.main(["-qq"], plugins=[self])
 
     @classmethod
     def run_tests(

--- a/bundled/tool/xray/utils.py
+++ b/bundled/tool/xray/utils.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
+import os
 from dataclasses import asdict
-from typing import Any, List, Optional, Self, Type
+from typing import Any, Callable, List, Optional, Self, Type, TypeVar
 
 
 class Config:
@@ -55,3 +57,17 @@ class ParserBuilder:
 
     def build(self) -> argparse.ArgumentParser:
         return self.parser
+
+
+T = TypeVar("T")
+
+
+def silence_output(f: Callable[..., T]) -> Callable[..., T]:
+    """Redirect the stdout to /dev/null"""
+
+    def wrapper(*args: Any, **kwargs: Any) -> T:
+        with open(os.devnull, "w") as devnull:
+            with contextlib.redirect_stdout(devnull):
+                return f(*args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
Ensures the output is fully usable by the extension